### PR TITLE
Bump symfony version to ^7.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   pull_request:
+  workflow_dispatch: ~
   push:
     branches:
       - 'main'
@@ -17,7 +18,7 @@ jobs:
       - name: 'Setup PHP'
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.1
+          php-version: 8.2
           ini-values: memory_limit=-1
           coverage: none
           tools: composer:v2
@@ -36,7 +37,7 @@ jobs:
       - name: 'Setup PHP'
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.1
+          php-version: 8.2
           ini-values: memory_limit=-1
           coverage: none
           tools: composer:v2
@@ -57,7 +58,7 @@ jobs:
       - name: 'Setup PHP'
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.1
+          php-version: 8.2
           ini-values: memory_limit=-1
           coverage: none
           tools: composer:v2
@@ -82,7 +83,7 @@ jobs:
       - name: 'Setup PHP'
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.1
+          php-version: 8.2
           ini-values: memory_limit=-1
           coverage: none
           tools: composer:v2
@@ -102,9 +103,9 @@ jobs:
       fail-fast: false
       matrix:
         php-version:
-          - '8.1'
+          - '8.2'
         symfony-version:
-          - '6.4'
+          - '7.0'
     steps:
       - name: 'Checkout Code'
         uses: actions/checkout@v4
@@ -139,7 +140,7 @@ jobs:
       - name: 'Setup PHP'
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.1
+          php-version: 8.2
           ini-values: memory_limit=-1
           coverage: pcov
           tools: composer:v2

--- a/composer.json
+++ b/composer.json
@@ -9,16 +9,16 @@
         "issues": "https://github.com/stfalcon-studio/swagger-bundle/issues"
     },
     "require": {
-        "php": ">=8.1",
+        "php": ">=8.2",
         "ext-ctype": "*",
         "ext-iconv": "*",
-        "symfony/console": "^6.4",
+        "symfony/console": "^7.0",
         "symfony/flex": "^v2.4",
-        "symfony/framework-bundle": "^6.4",
-        "symfony/twig-bundle": "^6.4",
-        "symfony/yaml": "^6.4",
-        "symfony/asset": "^6.4",
-        "symfony/finder": "^6.4",
+        "symfony/framework-bundle": "^7.0",
+        "symfony/twig-bundle": "^7.0",
+        "symfony/yaml": "^7.0",
+        "symfony/asset": "^7.0",
+        "symfony/finder": "^7.0",
         "symfony/polyfill-ctype": "^1.28",
         "twig/twig": "^3.8"
     },
@@ -30,9 +30,9 @@
         "phpstan/phpstan-symfony": "^1.3",
         "thecodingmachine/phpstan-strict-rules": "^1.0",
         "phpunit/phpunit": "^9.5",
-        "symfony/dotenv": "^6.4",
-        "symfony/filesystem": "^6.4",
-        "symfony/phpunit-bridge": "^6.4"
+        "symfony/dotenv": "^7.0",
+        "symfony/filesystem": "^7.0",
+        "symfony/phpunit-bridge": "^7.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Hi @fre5h , current PR updates symfony version to 7.0, dropping support for 6.4 version.

Do you think we'd need to support both 6.4 and 7.x simultaneously for some time? 

If so, I guess CI file needs to be changed to incorporate tests on different php versions (7.1 and 7.2 (required by sf 7.0)) and symfony versions.

Looks like there's currently not that much code out there to have support for these two.

Please, let me know what you think,
Thank you!




